### PR TITLE
Fix boombox volume not respecting game volume settings

### DIFF
--- a/Boombox/BoomboxBehaviour.cs
+++ b/Boombox/BoomboxBehaviour.cs
@@ -25,6 +25,15 @@ namespace Boombox
         {
             Click = transform.Find("SFX/Click").GetComponent<SFX_PlayOneShot>();
             Music = GetComponent<AudioSource>();
+            var gameHandler = GameHandler.Instance;
+            if (gameHandler != null)
+            {
+                var sfxVolumeSetting = gameHandler.SettingsHandler.GetSetting<SFXVolumeSetting>();
+                if (sfxVolumeSetting != null)
+                {
+                    Music.outputAudioMixerGroup = sfxVolumeSetting.mixerGroup;
+                }
+            }
         }
 
         public override void ConfigItem(ItemInstanceData data, PhotonView playerView)


### PR DESCRIPTION
First of all, love the mod!

We ran into an issue where the boombox doesn't respect the game's volume settings, so in certain cases it's still extremely loud even on 10%.

Did some digging and while I couldn't get the project to build (missing way too many references) to test the change, I believe this would fix the issue by playing the boombox's music on the SFX bus.

It still allows the players to change volume as currently, but the max volume will be clamped to whatever the game settings' SFX volume is set to, rather than the Windows volume's.